### PR TITLE
shouldBeRequiredToFailByメソッドをSlideMenuOptionsに追加

### DIFF
--- a/SlideMenuControllerSwift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SlideMenuControllerSwift.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -36,7 +36,7 @@ public struct SlideMenuOptions {
     public static var hideStatusBar: Bool = true
     public static var pointOfNoReturnWidth: CGFloat = 44.0
     public static var simultaneousGestureRecognizers: Bool = true
-    public static var reequiredToFailByGestureRecognizers: Bool = false
+    public static var requiredToFailByGestureRecognizers: Bool = false
 	public static var opacityViewBackgroundColor: UIColor = UIColor.black
     public static var panGesturesEnabled: Bool = true
     public static var tapGesturesEnabled: Bool = true
@@ -987,7 +987,7 @@ open class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
     }
 
     open func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return SlideMenuOptions.reequiredToFailByGestureRecognizers
+        return SlideMenuOptions.requiredToFailByGestureRecognizers
     }
     
     fileprivate func slideLeftForGestureRecognizer( _ gesture: UIGestureRecognizer, point:CGPoint) -> Bool{

--- a/Source/SlideMenuController.swift
+++ b/Source/SlideMenuController.swift
@@ -36,6 +36,7 @@ public struct SlideMenuOptions {
     public static var hideStatusBar: Bool = true
     public static var pointOfNoReturnWidth: CGFloat = 44.0
     public static var simultaneousGestureRecognizers: Bool = true
+    public static var reequiredToFailByGestureRecognizers: Bool = false
 	public static var opacityViewBackgroundColor: UIColor = UIColor.black
     public static var panGesturesEnabled: Bool = true
     public static var tapGesturesEnabled: Bool = true
@@ -983,6 +984,10 @@ open class SlideMenuController: UIViewController, UIGestureRecognizerDelegate {
     // returning true here helps if the main view is fullwidth with a scrollview
     open func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return SlideMenuOptions.simultaneousGestureRecognizers
+    }
+
+    open func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return SlideMenuOptions.reequiredToFailByGestureRecognizers
     }
     
     fileprivate func slideLeftForGestureRecognizer( _ gesture: UIGestureRecognizer, point:CGPoint) -> Bool{


### PR DESCRIPTION
https://qiita.com/ruwatana/items/16997b1b416512c20fb6#%E5%A4%B1%E6%95%97%E5%88%B6%E5%BE%A1%E7%B3%BB%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89

Gesture自身が他のGestureに対して失敗を要求するかどうかを制御するshouldBeRequiredToFailByメソッドをSlideMenuOptionsの Bool型のプロパティで指定できるよう拡張